### PR TITLE
Issues with long agendas

### DIFF
--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -55,10 +55,10 @@ class ReservationList extends Component {
     this.style = styleConstructor(props.theme);
 
     this.state = {
-      reservations: []
+      reservations: [],
+      heights: []
     };
 
-    this.heights = [];
     this.scrollOver = true;
     this.noUpdate = false;
     this.isTouched = false;
@@ -72,10 +72,10 @@ class ReservationList extends Component {
   componentDidUpdate(prevProps) {
     if (prevProps !== this.props) {
       if (!dateutils.sameMonth(prevProps.selectedDay, this.props.selectedDay)) {
-        this.heights = [];
         this.setState(
             {
-              reservations: []
+              reservations: [],
+              heights : []
             },
             () => this.updateReservations(this.props)
         );
@@ -165,14 +165,14 @@ class ReservationList extends Component {
     if (this.isTouched || this.noUpdate) return;
     if (!this.list) return;
 
-    if( this.heights.length !== this.state.reservations.length) {
+    if( this.state.heights.length !== this.state.reservations.length) {
       this.needToScroll = true;
       return;
     }
     let scrollPosition = 0;
     const toDay = this.props.selectedDay.getDate();
     for (let i = 0; i < toDay - 1; i++) {
-      scrollPosition += this.heights[i] || 0;
+      scrollPosition += this.state.heights[i] || 0;
     }
     this.scrollOver = false;
     if (this.list){
@@ -188,20 +188,21 @@ class ReservationList extends Component {
 
     let topRowOffset = 0;
     let topRow;
-    for (topRow = 0; topRow < this.heights.length; topRow++) {
-      if (topRowOffset + this.heights[topRow] * 0.7 >= yOffset) {
+    const heights = this.state.heights;
+    for (topRow = 0; topRow < heights.length; topRow++) {
+      if (topRowOffset + heights[topRow] * 0.7 >= yOffset) {
         break;
       }
-      topRowOffset += this.heights[topRow];
+      topRowOffset += heights[topRow];
     }
 
     const row = this.state.reservations[topRow];
     if (!row) return;
 
     if (
-      topRowOffset + this.heights[topRow] * 0.1 <= yOffset &&
-        topRowOffset + this.heights[topRow] * 0.95 >= yOffset &&
-        this.listHeight < this.heights[topRow]
+      topRowOffset + heights[topRow] * 0.1 <= yOffset &&
+        topRowOffset + heights[topRow] * 0.95 >= yOffset &&
+        this.listHeight < heights[topRow]
     ) {
       this.noUpdate = true;
     } else {
@@ -221,7 +222,15 @@ class ReservationList extends Component {
   }
 
   onRowLayoutChange(ind, event) {
-    this.heights[ind] = event.nativeEvent.layout.height;
+    const newHeight = [...this.state.heights];
+    newHeight[ind] = event.nativeEvent.layout.height;
+
+    this.setState(
+        {
+          reservations: this.state.reservations,
+          heights : newHeight
+        }
+    );
   }
 
   onMoveShouldSetResponderCapture = () => {
@@ -234,7 +243,7 @@ class ReservationList extends Component {
   renderRow = ({item, index}) => {
     const reservationProps = extractComponentProps(Reservation, this.props);
 
-    if( this.heights.length === this.state.reservations.length && this.needToScroll) {
+    if( this.state.heights.length === this.state.reservations.length && this.needToScroll) {
       this.updateScrollPosition();
     }
 

--- a/src/agenda/reservation-list/reservation.js
+++ b/src/agenda/reservation-list/reservation.js
@@ -1,26 +1,41 @@
 import _ from 'lodash';
+import PropTypes from 'prop-types';
+import XDate from 'xdate';
 import React, {Component} from 'react';
 import {View, Text} from 'react-native';
-
 import {xdateToData} from '../../interface';
-import XDate from 'xdate';
 import dateutils from '../../dateutils';
-import styleConstructor from './style';
 import {RESERVATION_DATE} from '../../testIDs';
+import styleConstructor from './style';
 
 class Reservation extends Component {
-  static displayName = 'Reservation';
+  static displayName = 'IGNORE';
+
+  static propTypes = {
+    item: PropTypes.any,
+    /** Specify theme properties to override specific styles for reservation parts. Default = {} */
+    theme: PropTypes.object,
+    /** specify your item comparison function for increased performance */
+    rowHasChanged: PropTypes.func,
+    /** specify how each date should be rendered. day can be undefined if the item is not first in that day */
+    renderDay: PropTypes.func,
+    /** specify how each item should be rendered in agenda */
+    renderItem: PropTypes.func,
+    /** specify how empty date content with no items should be rendered */
+    renderEmptyDate: PropTypes.func
+  };
 
   constructor(props) {
     super(props);
 
-    this.styles = styleConstructor(props.theme);
+    this.style = styleConstructor(props.theme);
   }
 
   shouldComponentUpdate(nextProps) {
     const r1 = this.props.item;
     const r2 = nextProps.item;
     let changed = true;
+
     if (!r1 && !r2) {
       changed = false;
     } else if (r1 && r2) {
@@ -43,45 +58,41 @@ class Reservation extends Component {
     if (_.isFunction(this.props.renderDay)) {
       return this.props.renderDay(date ? xdateToData(date) : undefined, item);
     }
-    const today = dateutils.sameDate(date, XDate())
-      ? this.styles.today
-      : undefined;
+
+    const today = dateutils.sameDate(date, XDate()) ? this.style.today : undefined;
     if (date) {
       return (
-        <View
-          style={[
-            this.styles.day,
-            {justifyContent: 'flex-start' /* , backgroundColor:'orange' */},
-          ]}
-          testID={RESERVATION_DATE}>
-          <Text allowFontScaling={false} style={[this.styles.dayNum, today]}>
+        <View style={this.style.day} testID={RESERVATION_DATE}>
+          <Text allowFontScaling={false} style={[this.style.dayNum, today]}>
             {date.getDate()}
           </Text>
-          <Text allowFontScaling={false} style={[this.styles.dayText, today]}>
+          <Text allowFontScaling={false} style={[this.style.dayText, today]}>
             {XDate.locales[XDate.defaultLocale].dayNamesShort[date.getDay()]}
           </Text>
         </View>
       );
     } else {
-      return <View style={this.styles.day} />;
+      return <View style={this.style.day}/>;
     }
   }
 
   render() {
     const {reservation, date} = this.props.item;
     let content;
+
     if (reservation) {
+      // const firstItem = date ? true : false;
       if (_.isFunction(this.props.renderItem)) {
         content = this.props.renderItem(reservation, date.toDate());
       }
     } else if (_.isFunction(this.props.renderEmptyDate)) {
       content = this.props.renderEmptyDate(date);
     }
-    return (
-      <View style={this.styles.container}>
-        {this.renderDate(date, reservation)}
 
-        <View style={{flex: 1}}>{content}</View>
+    return (
+      <View style={this.style.container}>
+        {this.renderDate(date, reservation)}
+        <View style={this.style.innerContainer}>{content}</View>
       </View>
     );
   }

--- a/src/agenda/reservation-list/style.js
+++ b/src/agenda/reservation-list/style.js
@@ -8,12 +8,11 @@ export default function styleConstructor(theme = {}) {
   return  StyleSheet.create({
     container: {
       flexDirection: 'row',
-      // backgroundColor:'yellow',
       marginVertical:2,
       paddingVertical:8
-      // justifyContent:'flex-start',
-      // alignItems:'flex-start',
-      // alignContent:'flex-start'
+    },
+    innerContainer: {
+      flex: 1
     },
     dayNum: {
       fontSize: 28,
@@ -35,10 +34,12 @@ export default function styleConstructor(theme = {}) {
       alignItems: 'center',
       justifyContent: 'flex-start',
       // marginTop: 8,
-      // alignSelf:'flex-start'
     },
     today: {
       color: appStyle.agendaTodayColor
+    },
+    indicator: {
+      marginTop: 80
     },
     ...(theme[STYLESHEET_ID] || {})
   });

--- a/src/component-updater.js
+++ b/src/component-updater.js
@@ -10,6 +10,21 @@ function shouldUpdate(a, b, paths) {
   return false;
 }
 
+function extractComponentProps(component, props, ignoreProps) {
+  const componentPropTypes = component.propTypes;
+  if (componentPropTypes) {
+    const keys = Object.keys(componentPropTypes);
+    const componentProps = _.chain(props)
+        .pickBy((_value, key) => _.includes(keys, key))
+        .omit(ignoreProps)
+        .value();
+    return componentProps;
+  }
+  return {};
+}
+
+
 module.exports = {
-  shouldUpdate
+  shouldUpdate,
+  extractComponentProps
 };


### PR DESCRIPTION
Updated files from  src/agenda/reservation-list with what is now in the original library and then fixed the differences we had in the forked lib. 
Currently the official lib has in componentDidUpdate(prevProps) a call for updateReservations even when props didn't changed and this was causing the app to crash with too many state updates. Also moved heights into state to beter handle updates on month change. And added initialNumToRender={31} because heights are calculated onLayout for rows and for end of the month dates it was not having the heights.

This update was focused on the agenda part, but the calendar part could also benefit on some updates. 