### PR TITLE
P2-1572-update agenda list after deleting one reservation

### DIFF
--- a/src/agenda/reservation-list/index.js
+++ b/src/agenda/reservation-list/index.js
@@ -80,6 +80,11 @@ class ReservationList extends Component {
             () => this.updateReservations(this.props)
         );
       }
+
+      if(prevProps.reservations!== this.props?.reservations){
+        this.updateReservations(this.props)
+      }
+
       if (!dateutils.sameDate(prevProps.selectedDay, this.props.selectedDay)) {
         this.needToScroll = true;
       }


### PR DESCRIPTION
For optimizing the agenda list , in my previous PR I've reduce the number of calls for updateReservations but I missed the case when the reservations prop value changes, for example on deleting one reservation, and this is the fix for it.